### PR TITLE
Updated template config routes to use multi-line blocks

### DIFF
--- a/lib/hanamismith/templates/%project_name%/config/routes.rb.erb
+++ b/lib/hanamismith/templates/%project_name%/config/routes.rb.erb
@@ -1,7 +1,11 @@
 <% namespace do %>
   # Configures application routes.
   class Routes < Hanami::Routes
-    slice(:health, at: "/status") { root to: "show" }
-    slice(:main, at: "/") { root to: "home.show" }
+    slice :health, at: "/status" do
+      root to: "show"
+    end
+    slice :main, at: "/" do
+      root to: "home.show"
+    end
   end
 <% end %>

--- a/spec/lib/hanamismith/builders/core_spec.rb
+++ b/spec/lib/hanamismith/builders/core_spec.rb
@@ -79,8 +79,12 @@ RSpec.describe Hanamismith::Builders::Core do
         module Test
           # Configures application routes.
           class Routes < Hanami::Routes
-            slice(:health, at: "/status") { root to: "show" }
-            slice(:main, at: "/") { root to: "home.show" }
+            slice :health, at: "/status" do
+              root to: "show"
+            end
+            slice :main, at: "/" do
+              root to: "home.show"
+            end
           end
         end
       CONTENT


### PR DESCRIPTION

## Overview

When generating an application with hanamismith the hanami generate command for an action fails.

## Details

For instance, following the readme:

```bash
cd demo
bin/setup
bin/hanami db create
```

If I then try to run:

```
hanami g action home.subscribe --slice=main --url='/subscribe' --http=post
```

I receive the error:

```
/Users/me/.gem/ruby/3.2.0/gems/dry-files-1.0.1/lib/dry/files.rb:957:in `index': cannot find `(?-mix:slice[[:space:]]*:main)' in `config/routes.rb' (Dry::Files::MissingTargetError)
  from /Users/me/.gem/ruby/3.2.0/gems/dry-files-1.0.1/lib/dry/files.rb:685:in `inject_line_at_block_bottom'
  from /Users/me/.gem/ruby/3.2.0/gems/hanami-cli-2.0.3/lib/hanami/cli/generators/app/action.rb:73:in `generate_for_slice'
  from /Users/me/.gem/ruby/3.2.0/gems/hanami-cli-2.0.3/lib/hanami/cli/generators/app/action.rb:28:in `call'
  from /Users/me/.gem/ruby/3.2.0/gems/hanami-cli-2.0.3/lib/hanami/cli/commands/app/generate/action.rb:72:in `call'
  from /Users/me/.gem/ruby/3.2.0/gems/hanami-cli-2.0.3/lib/hanami/cli/commands/app/command.rb:40:in `call'
  from /Users/me/.gem/ruby/3.2.0/gems/dry-cli-1.0.0/lib/dry/cli.rb:116:in `perform_registry'
  from /Users/me/.gem/ruby/3.2.0/gems/dry-cli-1.0.0/lib/dry/cli.rb:65:in `call'
  from /Users/me/.gem/ruby/3.2.0/gems/hanami-cli-2.0.3/exe/hanami:11:in `<top (required)>'
  from /Users/me/.gem/ruby/3.2.0/bin/hanami:25:in `load'
  from /Users/me/.gem/ruby/3.2.0/bin/hanami:25:in `<main>'
```

I believe this is because the hanami generator attempts to find a matching slice via a regular expression. When a match cannot be found the error is raised.

I have changed the templated `routes.rb` file to use syntax that is compatible with the hanami generator code.

A followup PR to hanami to make the _inject line_ code less specific may be a better long term solution.
